### PR TITLE
구독 카드 배경색 적용

### DIFF
--- a/src/components/SubscribeCard/style.js
+++ b/src/components/SubscribeCard/style.js
@@ -11,12 +11,9 @@ export const Card = styled.div`
   right: 20px;
   width: 250px;
   height: 130px;
-  background: rgba(255, 255, 255, 0.25);
-  box-shadow: 0 8px 20px 0 rgba(31, 38, 135, 0.37);
-  backdrop-filter: blur(8.5px);
-  -webkit-backdrop-filter: blur(8.5px);
-  border-radius: 10px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
+  background-color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0px 0px 10px 0px #00000040;
 `;
 
 export const Content = styled.p`


### PR DESCRIPTION
## 개요 🪧

- 구독 카드 배경색 적용

## 작업 내용 📄

- 글라스모피즘이 적용되었던 내용이 가독성이 떨어져 기존 스타일로 변경하였습니다. 

## 스크린샷 📸

<img width="612" alt="image" src="https://user-images.githubusercontent.com/54930877/155647318-61a4212c-af40-4012-b0ac-14ed0ca1cea7.png">

